### PR TITLE
Updated to work with current Stripe-PHP

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 stripe-terminal is a single form that allows anyone with a [Stripe.com](https://stripe.com/) account to submit credit card charges from any web browser.
 
+This Repository is based on @wlrs' origional Stripe-Terminal repository at [https://github.com/wlrs/stripe-terminal](https://github.com/wlrs/stripe-terminal)
+This is an update to work with Stripe's latest API located at: [https://github.com/stripe/stripe-php](https://github.com/stripe/stripe-php)
+
 ### Features
 
  * Simple javascript validation of data

--- a/README.md
+++ b/README.md
@@ -6,6 +6,15 @@ This Repository is based on [@wlrs](https://github.com/wlrs/stripe-terminal)' or
 
 This is an update to work with Stripe's latest API located at: [https://github.com/stripe/stripe-php](https://github.com/stripe/stripe-php)
 
+### New Version
+A new version has been created. This is a fully revamped update to work with Stripe's latest API located at: [https://github.com/stripe/stripe-php](https://github.com/stripe/stripe-php) as well as Stripe.js (version 3.0)
+
+You can find it here: [https://github.com/bateller/stripe-terminal-new](https://github.com/bateller/stripe-terminal-new)
+
+The new version also no longer requires JQuery
+
+Because the new version is so different, I am keeping this repo separate.
+
 ### Features
 
  * Simple javascript validation of data

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Stripe accounts are free but require a US-based checking account to actually cre
 
 Just clone this repo into a clean directory. `stripe-php` is included as a submodule so using the `--recursive` flag will get you everything:
 
-	git clone --recursive git://github.com/wlrs/stripe-terminal.git .
+	git clone --recursive git://github.com/bateller/stripe-terminal.git .
 
 Then just set `$key_publishable` and `$key_secret` in index.php and you're good to go.
 
@@ -30,6 +30,7 @@ Stripe.com provides "test" and "live" API keys, you should start with your test 
 
 ### Demo
 
-[https://wlrs.net/stripe-terminal/demo/](https://wlrs.net/stripe-terminal/demo/)
+No live demo right now.
+# [https://wlrs.net/stripe-terminal/demo/](https://wlrs.net/stripe-terminal/demo/)
 
 The demo is running in test mode, but please don't submit real credit card information.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 stripe-terminal is a single form that allows anyone with a [Stripe.com](https://stripe.com/) account to submit credit card charges from any web browser.
 
-This Repository is based on @wlrs' origional Stripe-Terminal repository at [https://github.com/wlrs/stripe-terminal](https://github.com/wlrs/stripe-terminal)
+This Repository is based on @wlrs' original Stripe-Terminal repository at [https://github.com/wlrs/stripe-terminal](https://github.com/wlrs/stripe-terminal)
 
 This is an update to work with Stripe's latest API located at: [https://github.com/stripe/stripe-php](https://github.com/stripe/stripe-php)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 stripe-terminal is a single form that allows anyone with a [Stripe.com](https://stripe.com/) account to submit credit card charges from any web browser.
 
-This Repository is based on @wlrs' original Stripe-Terminal repository at [https://github.com/wlrs/stripe-terminal](https://github.com/wlrs/stripe-terminal)
+This Repository is based on [https://github.com/wlrs/stripe-terminal](@wlrs)' original Stripe-Terminal repository at [https://github.com/wlrs/stripe-terminal](https://github.com/wlrs/stripe-terminal)
 
 This is an update to work with Stripe's latest API located at: [https://github.com/stripe/stripe-php](https://github.com/stripe/stripe-php)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 stripe-terminal is a single form that allows anyone with a [Stripe.com](https://stripe.com/) account to submit credit card charges from any web browser.
 
-This Repository is based on [https://github.com/wlrs/stripe-terminal](@wlrs)' original Stripe-Terminal repository at [https://github.com/wlrs/stripe-terminal](https://github.com/wlrs/stripe-terminal)
+This Repository is based on [@wlrs](https://github.com/wlrs/stripe-terminal)' original Stripe-Terminal repository at [https://github.com/wlrs/stripe-terminal](https://github.com/wlrs/stripe-terminal)
 
 This is an update to work with Stripe's latest API located at: [https://github.com/stripe/stripe-php](https://github.com/stripe/stripe-php)
 

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 stripe-terminal is a single form that allows anyone with a [Stripe.com](https://stripe.com/) account to submit credit card charges from any web browser.
 
 This Repository is based on @wlrs' origional Stripe-Terminal repository at [https://github.com/wlrs/stripe-terminal](https://github.com/wlrs/stripe-terminal)
+
 This is an update to work with Stripe's latest API located at: [https://github.com/stripe/stripe-php](https://github.com/stripe/stripe-php)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Stripe.com provides "test" and "live" API keys, you should start with your test 
 
 ### Demo
 
-No live demo right now.
-# [https://wlrs.net/stripe-terminal/demo/](https://wlrs.net/stripe-terminal/demo/)
+[https://wbat.net/stripe-terminal-demo/](https://wbat.net/stripe-terminal-demo/)
 
 The demo is running in test mode, but please don't submit real credit card information.

--- a/index.php
+++ b/index.php
@@ -90,7 +90,7 @@ if($_POST){
                 <label>Card Number</label>
 
                 <div class="form_input">
-                    <input id="input_number" type="text" pattern="[0-9]*"/>
+                    <input id="input_number" type="text" pattern="[0-9]*" maxlength="16" />
                 </div>
                 
                 <div class="clear"></div>
@@ -100,7 +100,7 @@ if($_POST){
                 <label>CVC</label>
 
                 <div class="form_input">
-                    <input id="input_cvc" type="text" pattern="[0-9]*" />
+                    <input id="input_cvc" type="text" pattern="[0-9]*" maxlength="4" />
                 </div>
 
                 <div class="clear"></div>
@@ -110,9 +110,9 @@ if($_POST){
                 <label>Expiration</label>
 
                 <div class="form_input">
-                    <input id="input_exp_month" type="text" pattern="[0-9]*" placeholder="MM" />
+                    <input id="input_exp_month" type="text" pattern="[0-9]*" placeholder="MM" maxlength="2" />
                     <span> / </span>
-                    <input id="input_exp_year" type="text" pattern="[0-9]*" placeholder="YYYY" />
+                    <input id="input_exp_year" type="text" pattern="[0-9]*" placeholder="YYYY" maxlength="4" />
                 </div>
                     
                 <div class="clear"></div>

--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ $demo_mode          = false;
 if(!$key_publishable || !$key_secret) die('Please set stripe API keys');
 
 if($_POST){
-    require_once 'stripe-php/lib/Stripe.php';
+    require 'stripe-php/init.php';
 
     $note_parts = array();
     if($note_prefix) $note_parts[] = $note_prefix;
@@ -35,15 +35,20 @@ if($_POST){
     );
 
     try{
-        Stripe::setApiKey($key_secret);
-        $charge = Stripe_Charge::create($params);
+        if (!isset($_POST['token'])) {
+                $response['error'] = "The Stripe Token was not generated correctly";
+                $response['success'] = false;
+        } else {
+                \Stripe\Stripe::setApiKey($key_secret);
+                $charge = \Stripe\Charge::create($params);
 
-        $response['success']    = true;
-        $response['id']         = $charge->id;
-        $response['amount']     = number_format($charge->amount / 100, 2);
-        $response['fee']        = number_format($charge->fee / 100, 2);
-        $response['card_type']  = $charge->card->type;
-        $response['card_last4'] = $charge->card->last4;
+                $response['success']    = true;
+                $response['id']         = $charge->id;
+                $response['amount']     = number_format($charge->amount / 100, 2);
+                $response['fee']        = number_format($charge->fee / 100, 2);
+                $response['card_type']  = $charge->card->type;
+                $response['card_last4'] = $charge->card->last4;
+        }
     }catch (Exception $e) {
         $response['error'] = $e->getMessage();
     }
@@ -51,7 +56,6 @@ if($_POST){
     echo json_encode($response);
     die();
 }
-
 ?>
 <!DOCTYPE html>
 <html>
@@ -137,7 +141,7 @@ if($_POST){
             </form>
         </div>
 
-        <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js"></script>
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
         <script type="text/javascript" src="https://js.stripe.com/v1/"></script>
         <script type="text/javascript" src="form.js?<?= filemtime('form.js') ?>"></script>
         <script type="text/javascript">


### PR DESCRIPTION
The original code provided by wlrs only works with the commit that it is linked. It will not work with the current version of Stripe-PHP that uses namespaces. This pull-request fixes that issue and also includes latest JQuery for good measure.
